### PR TITLE
Make children optional

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -29,7 +29,7 @@ export interface FoldableLoggerProps {
   autoScroll?: boolean;
   showHeader?: boolean;
   linkify?: boolean;
-  children: ({
+  children?: ({
     hasError,
     errors,
   }: {


### PR DESCRIPTION
Children are already optional because they are null checked before being used, but this makes it so TypeScript won't complain if you don't include children. 