### PR TITLE
Add key to <Line>

### DIFF
--- a/src/component/RawLogger.tsx
+++ b/src/component/RawLogger.tsx
@@ -148,6 +148,7 @@ export function RawLogger({
     return lines.map((line, index) => (
       <Line
         {...lineProps}
+        key={index}
         line={line.content}
         errors={line.errors}
         index={index}


### PR DESCRIPTION
Add key to <Line> to avoid `Warning: Each child in a list should have a unique "key" prop.`